### PR TITLE
Fix jabber authentication bug.

### DIFF
--- a/libpurple/account.c
+++ b/libpurple/account.c
@@ -1389,18 +1389,24 @@ purple_account_get_password_got(PurpleAccount *account,
 	g_free(cbb);
 }
 
-void
+const gchar *
 purple_account_get_password(PurpleAccount *account,
 	PurpleKeyringReadCallback cb, gpointer data)
 {
 	PurpleAccountPrivate *priv;
 
 	if (account == NULL) {
-		cb(NULL, NULL, NULL, data);
-		return;
+		if(cb != NULL)
+			cb(NULL, NULL, NULL, data);
+		return NULL;
 	}
 
 	priv = PURPLE_ACCOUNT_GET_PRIVATE(account);
+	if(cb == NULL) {
+		if(priv != NULL && priv->password != NULL)
+			return priv->password;
+		return NULL;
+	}
 
 	if (priv->password != NULL) {
 		purple_debug_info("account",
@@ -1418,6 +1424,7 @@ purple_account_get_password(PurpleAccount *account,
 		purple_keyring_get_password(account, 
 			purple_account_get_password_got, cbb);
 	}
+	return NULL;
 }
 
 const char *

--- a/libpurple/account.h
+++ b/libpurple/account.h
@@ -695,7 +695,7 @@ const char *purple_account_get_username(const PurpleAccount *account);
 /**
  * purple_account_get_password:
  * @account: The account.
- * @cb:      (scope call): The callback to give the password.
+ * @cb:      (scope call): The callback to give the password. (can be NULL)
  * @data:    A pointer passed to the callback.
  *
  * Reads the password for the account.
@@ -704,8 +704,14 @@ const char *purple_account_get_username(const PurpleAccount *account);
  * once it has been read from the keyring. If the account is connected, and you
  * require the password immediately, then consider using @ref
  * purple_connection_get_password instead.
+ *
+ * If @cb is NULL, it tries to fetch the password from the local account
+ * (and not try to fetch from keyring).
+ *
+ * Returns: the password, when cb is NULL and it finds the password
+ *          NULL in all other cases (including when cb is not NULL)
  */
-void purple_account_get_password(PurpleAccount *account,
+const gchar *purple_account_get_password(PurpleAccount *account,
 	PurpleKeyringReadCallback cb, gpointer data);
 
 /**

--- a/libpurple/connection.c
+++ b/libpurple/connection.c
@@ -348,9 +348,16 @@ purple_connection_get_password(const PurpleConnection *gc)
 {
 	PurpleConnectionPrivate *priv = PURPLE_CONNECTION_GET_PRIVATE(gc);
 
-	g_return_val_if_fail(priv != NULL, NULL);
+	g_return_val_if_fail(gc != NULL, NULL);
 
-	return priv->password;
+	if(priv != NULL && priv->password)
+		return priv->password;
+
+	PurpleAccount *account = purple_connection_get_account(gc);
+	if(account != NULL)
+		return purple_account_get_password(account, NULL, NULL);
+
+	return NULL;
 }
 
 GSList *

--- a/libpurple/connection.h
+++ b/libpurple/connection.h
@@ -411,9 +411,10 @@ PurplePlugin *purple_connection_get_prpl(const PurpleConnection *gc);
  * purple_connection_get_password:
  * @gc: The connection.
  *
- * Returns the connection's password.
+ * For legacy support, this fetches the account password when there
+ * is no connection password available and returns that.
  *
- * Returns: The connection's password.
+ * Returns: The connection's password or account's password.
  */
 const char *purple_connection_get_password(const PurpleConnection *gc);
 


### PR DESCRIPTION
It goes into infinite loop of requesting password when
jabber is compiled with --enable-cyrus-sasl

This seems to be because of API changes in the core. The
fix proposes better legacy support at least until all the
protocols are fixed to use the newer API style.
